### PR TITLE
pre-parse changed the lib dir.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN cd /code && \
     cp -R ../third_party_temp/* ./ && \
     cd pe-parse && \
     cmake -D CMAKE_CXX_FLAGS=-Wstrict-overflow=1 . && \
-    sed -i -e 's/overflow\=5/overflow\=1/g' ./parser-library/CMakeFiles/pe-parser-library.dir/flags.make && \
-    cat ./parser-library/CMakeFiles/pe-parser-library.dir/flags.make && \
+    sed -i -e 's/overflow\=5/overflow\=1/g' ./cmake/compilation_flags.cmake && \
+    cat ./cmake/compilation_flags.cmake && \
     make -j 16 && \
     cd ../spii && \
     cmake . -DBUILD_SHARED_LIBS=true && \
@@ -56,6 +56,5 @@ RUN cd /code && \
 #    docker run -it --rm -v $(pwd):/pwd functionsimsearch disassemble ELF /pwd/someexe
 VOLUME /pwd
 WORKDIR /code/functionsimsearch
-ADD ./entrypoint.sh /root/entrypoint.sh
-RUN chmod +x /root/entrypoint.sh
-ENTRYPOINT ["/root/entrypoint.sh"]
+RUN chmod +x /code/functionsimsearch/entrypoint.sh
+ENTRYPOINT ["/code/functionsimsearch/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CPP = g++
 CPPFLAGS += -ggdb -O3 -std=c++11 -D_DEBUG -fPIE
-LIBDIR = -L./third_party/pe-parse/parser-library -L./third_party/libdwarf/libdwarf
+LIBDIR = -L./third_party/pe-parse/pe-parser-library -L./third_party/libdwarf/libdwarf
 INCLUDEDIR = -Ithird_party/spii/include -Ithird_party/spii/thirdparty/Eigen
 LIBS = -lparseAPI -linstructionAPI -lsymtabAPI -lsymLite -ldynDwarf -ldynElf \
        -lcommon -lelf -ldwarf -lpthread -lpe-parser-library -lspii -lgflags

--- a/pecodesource.cpp
+++ b/pecodesource.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "third_party/pe-parse/parser-library/parse.h"
-#include "third_party/pe-parse/parser-library/nt-headers.h"
+#include "third_party/pe-parse/pe-parser-library/include/parser-library/parse.h"
+#include "third_party/pe-parse/pe-parser-library/include/parser-library/nt-headers.h"
 
 #include "pecodesource.hpp"
 


### PR DESCRIPTION
Hello!

The docker script failed as the [third-party lib pre-parse](https://github.com/trailofbits/pe-parse) changed their library directory. I updated the docker script, includes and Makefile. The 'ADD' command does not work on Windows thus I changed to directly put entrypoint.sh as entry point. Let me know if that will be a concern.

Thank you!

Steven