### PR TITLE
Python bindings: Return PyObject with PyMODINIT_FUNC macro

### DIFF
--- a/pybindings/pybindings.cpp
+++ b/pybindings/pybindings.cpp
@@ -22,7 +22,7 @@
 #else
   #define MOD_ERROR_VAL
   #define MOD_SUCCESS_VAL(val)
-  #define MOD_INIT(name) void init##name(void)
+  #define MOD_INIT(name) PyMODINIT_FUNC init##name(void)
   #define MOD_DEF(ob, name, doc, methods) \
           ob = Py_InitModule3(name, methods, doc);
 #endif


### PR DESCRIPTION
This is to solve a 'ImportError: dynamic module does not define init function (initfunctionsimsearch)' error when running python -c "import functionsimsearch".
I'm running Python 2.7.12.
